### PR TITLE
correct the createDeriveKey function signature in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@
     - [Hasher](#hasher)
       - [`createHash(): Hasher`](#createhash-hasher)
       - [`createKeyed(key: Buffer): Hasher`](#createkeyedkey-buffer-hasher)
-      - [`createDeriveKey(key: Buffer): Hasher`](#createderivekeykey-buffer-hasher)
+      - [`createDeriveKey(context: string): Hasher`](#createderivekeykey-buffer-hasher)
       - [`hasher.update(data: BinaryLike): this`](#hasherupdatedata-binarylike-this)
       - [`hasher.digest(encoding?: string, options?: { length: number, dispose: boolean })): Buffer | string`](#hasherdigestencoding-string-options--length-number-dispose-boolean--buffer--string)
       - [`hasher.reader(options?: { dispose: boolean }): HashReader`](#hasherreaderoptions--dispose-boolean--hashreader)
@@ -38,7 +38,7 @@
     - [Hasher](#hasher-1)
       - [`createHash(): Hasher`](#createhash-hasher-1)
       - [`createKeyed(key: Buffer): Hasher`](#createkeyedkey-buffer-hasher-1)
-      - [`createDeriveKey(key: Buffer): Hasher`](#createderivekeykey-buffer-hasher-1)
+      - [`createDeriveKey(context: string): Hasher`](#createderivekeykey-buffer-hasher-1)
       - [`hasher.update(data: BinaryLike): this`](#hasherupdatedata-binarylike-this-1)
       - [`hasher.digest(encoding?: 'hex' | 'base64' | 'utf8', options?: { length: number, dispose: boolean })): Hash | string`](#hasherdigestencoding-hex--base64--utf8-options--length-number-dispose-boolean--hash--string)
       - [`hasher.reader(options?: { dispose: boolean }): HashReader`](#hasherreaderoptions--dispose-boolean--hashreader-1)
@@ -138,7 +138,7 @@ Creates a new hasher instance using the standard hash function.
 
 Creates a new hasher instance for a keyed hash. For more information, see [the blake3 docs](https://docs.rs/blake3/0.1.3/blake3/fn.keyed_hash.html).
 
-##### `createDeriveKey(key: Buffer): Hasher`
+##### `createDeriveKey(context: string): Hasher`
 
 Creates a new hasher instance for the key derivation function. For more information, see [the blake3 docs](https://docs.rs/blake3/0.1.3/blake3/fn.derive_key.html).
 
@@ -283,7 +283,7 @@ Creates a new hasher instance using the standard hash function.
 
 Creates a new hasher instance for a keyed hash. For more information, see [the blake3 docs](https://docs.rs/blake3/0.1.3/blake3/fn.keyed_hash.html).
 
-##### `createDeriveKey(key: Buffer): Hasher`
+##### `createDeriveKey(context: string): Hasher`
 
 Creates a new hasher instance for the key derivation function. For more information, see [the blake3 docs](https://docs.rs/blake3/0.1.3/blake3/fn.derive_key.html).
 


### PR DESCRIPTION
If I'm reading the code correctly, this function takes a context string, which is definitely the right thing for it to take. But the readme described it as taking a key, maybe because of a paste-o?