### PR TITLE
update the Rust crate to v0.2 and enable the "c" feature

### DIFF
--- a/rs/native/Cargo.toml
+++ b/rs/native/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 neon-build = "0.3.3"
 
 [dependencies]
-blake3 = "0.1"
+blake3 = "0.2"
 neon = "0.3"

--- a/rs/native/Cargo.toml
+++ b/rs/native/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 neon-build = "0.3.3"
 
 [dependencies]
-blake3 = "0.2"
+blake3 = { version = "0.2", features = ["c"] }
 neon = "0.3"

--- a/rs/wasm/Cargo.toml
+++ b/rs/wasm/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-blake3 = "0.1"
+blake3 = "0.2"
 wasm-bindgen = "0.2"


### PR DESCRIPTION
This should be a measurable performance improvement in the native build. That said, I'm not quite sure how to test or benchmark this project properly :)

One of the things changed from v0.1 to v0.2 is that multithreading can now be enabled on a per-caller basis. This library could consider exposing a boolean `multithreading` flag or something like that, as I've done in https://github.com/oconnor663/blake3-py. I don't know what the multithreading story is for Wasm (I assume there isn't one yet?), but fingers crossed with the native build it could Just Work.