### PR TITLE
Update the Rust crate to v0.3 and disable unsupport "c" feature

### DIFF
--- a/.github/workflows/build-neon.yml
+++ b/.github/workflows/build-neon.yml
@@ -22,7 +22,7 @@ jobs:
           toolchain: nightly
       - uses: actions/setup-node@v1
         with:
-          node-version: v14.2.0
+          node-version: v14.6.0
       - run: npm install neon-cli rimraf
       - run: ../node_modules/.bin/neon build --release
         working-directory: rs
@@ -40,7 +40,7 @@ jobs:
       - run: 'mv rs/native/index.node dist/${{ matrix.os }}-79.node'
       - uses: actions/setup-node@v1
         with:
-          node-version: v12.16.3
+          node-version: v12.18.3
       - shell: powershell
         name: patch node-gyp for VS 2019
         run: "npm install --global node-gyp@latest\r\nnpm prefix -g | % {npm config set node_gyp \"$_\\node_modules\\node-gyp\\bin\\node-gyp.js\"}"
@@ -62,7 +62,7 @@ jobs:
       - run: 'mv rs/native/index.node dist/${{ matrix.os }}-67.node'
       - uses: actions/setup-node@v1
         with:
-          node-version: v10.20.1
+          node-version: v10.22.0
       - shell: powershell
         name: patch node-gyp for VS 2019
         run: "npm install --global node-gyp@latest\r\nnpm prefix -g | % {npm config set node_gyp \"$_\\node_modules\\node-gyp\\bin\\node-gyp.js\"}"

--- a/readme.md
+++ b/readme.md
@@ -361,20 +361,23 @@ using(hash.reader(), async reader => {
 
 You can run benchmarks by installing `npm install -g @c4312/matcha`, then running `matcha benchmark.js`. These are the results running on Node 12 on my MacBook. Blake3 is significantly faster than Node's built-in hashing.
 
-      337,000 ops/sec > 64B#md5
-      302,000 ops/sec > 64B#sha1
-      276,000 ops/sec > 64B#sha256
-      752,000 ops/sec > 64B#blake3
+        276,000 ops/sec > 64B#md5 (4,240x)
+        263,000 ops/sec > 64B#sha1 (4,040x)
+        271,000 ops/sec > 64B#sha256 (4,160x)
+      1,040,000 ops/sec > 64B#blake3 wasm (15,900x)
+        625,000 ops/sec > 64B#blake3 native (9,590x)
 
-        11,700 ops/sec > 64KB#md5
-        16,100 ops/sec > 64KB#sha1
-         7,550 ops/sec > 64KB#sha256
-        52,800 ops/sec > 64KB#blake3
+          9,900 ops/sec > 64KB#md5 (152x)
+         13,900 ops/sec > 64KB#sha1 (214x)
+          6,470 ops/sec > 64KB#sha256 (99.2x)
+          6,410 ops/sec > 64KB#blake3 wasm (98.4x)
+         48,900 ops/sec > 64KB#blake3 native (750x)
 
-           124 ops/sec > 6MB#md5
-           175 ops/sec > 6MB#sha1
-          80.2 ops/sec > 6MB#sha256
-           518 ops/sec > 6MB#blake3
+            106 ops/sec > 6MB#md5 (1.63x)
+            150 ops/sec > 6MB#sha1 (2.3x)
+           69.2 ops/sec > 6MB#sha256 (1.06x)
+           65.2 ops/sec > 6MB#blake3 wasm (1x)
+            502 ops/sec > 6MB#blake3 native (7.7x)
 
 ## Contributing
 

--- a/rs/native/Cargo.toml
+++ b/rs/native/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 neon-build = "0.3.3"
 
 [dependencies]
-blake3 = { version = "0.2", features = ["c"] }
+blake3 = "0.3"
 neon = "0.3"

--- a/rs/wasm/Cargo.toml
+++ b/rs/wasm/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-blake3 = "0.2"
+blake3 = "0.3"
 wasm-bindgen = "0.2"


### PR DESCRIPTION
Since v3.0, the optimized assembly implementations are now built by default and do not need to activate "c" feature.