### PR TITLE
Update node import to specify index

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -13,4 +13,4 @@ if ((process as any).browser) {
   );
 }
 
-export * from './node';
+export * from './node/index';


### PR DESCRIPTION
Trying to troubleshoot why Vite can't seem to bundle this package correct, and it looks like the built source tries to import `./node.js` instead of `./node`. Looks like there is a utility function that adds `.js` to the end of all of the imports, but this one was not updated to include the reference to the `index.js` that is generated.