### PR TITLE
fix version

### DIFF
--- a/blake3-wasm/package.json
+++ b/blake3-wasm/package.json
@@ -25,6 +25,6 @@
   "author": "Connor Peet <connor@peet.io>",
   "license": "MIT",
   "dependencies": {
-    "@c4312/blake3-internal": "2.1.7"
+    "@c4312/blake3-internal": "^3.0.0"
   }
 }


### PR DESCRIPTION
fix 
```
❯ ni blake3-wasm

 ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @c4312/blake3-internal@2.1.7

This error happened while installing the dependencies of blake3-wasm@3.0.0

The latest release of @c4312/blake3-internal is "3.0.0".

If you need the full list of all 1 published versions run "$ pnpm view @c4312/blake3-internal versions".
Progress: resolved 65, reused 65, downloaded 0, added 0
```